### PR TITLE
Feature/named items

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can then give perk.kit2 permission when the player reaches level 20 with ski
 | epic.salvage				| the player can salvage epic items from menu		|
 | epic.enhance				| the player can add epic buffs to items			|
 | free						| the player can modify all items for free			|
-| settings.hide_button		| the player can hide the main button				|
+| settings.hide_button		| reserved for settings menu				        |
 
 ## Configurations
 The plugin is reading configurations from Epic Loot and Item Perk when starting.
@@ -203,6 +203,8 @@ Additional costs can be defined according to other perk crafting actions.
 
 The player will not be able to improve chances with kits.
 Kits are disabled and rolls rely fully on perk weights.
+
+A minimum weight can be set to improve chances for rare mods while unveiling.
 
 ## Translations
 You will find out when looking into the language file, that this plugin barely uses translations.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ You can then give perk.kit2 permission when the player reaches level 20 with ski
 | epic.salvage				| the player can salvage epic items from menu		|
 | epic.enhance				| the player can add epic buffs to items			|
 | free						| the player can modify all items for free			|
+| settings.hide_button		| the player can hide the main button				|
 
 ## Configurations
 The plugin is reading configurations from Epic Loot and Item Perk when starting.
@@ -190,16 +191,14 @@ Because of the advanced crafting options for perks, this plugin will have its ow
 
 You can add default additional costs for each craft type.
 Simply set the values for "Item to use when ... a perk".
-The default costs is set to use epic scrap.
-
-*If your server is not supporting epic, you should change that.*
+The default costs is set to use scrap.
 
 Additional costs can be increased for each kit used during crafting process depending on the perk of the kit.
 
 ### Named Items
 Named items can be restricted and unrestricted.
 If restricted, the player cant reveal additional perks.
-For unrestricted items, the player can unveil additional perks, if the total amount of perks is not exceeding the max allowed number.
+The player can unveil additional perks for unrestricted items, if the total amount of perks is not exceeding the max allowed number.
 Additional costs can be defined according to other perk crafting actions.
 
 The player will not be able to improve chances with kits.


### PR DESCRIPTION
[feature] possible to bypass white and blacklists of perks when unveiling for named items
[feature] possible to set min weight for perks when unveiling
[feature] named items will have now additional icons, so its easiert to identify them
[UX] increased the space for perk names when showing slider ranges. It should happen less often, that only half the name is shown.